### PR TITLE
Added * to remove issue where LabNet has # at end

### DIFF
--- a/functions/public.ps1
+++ b/functions/public.ps1
@@ -415,7 +415,7 @@ Function Enable-Internet {
     $NatNetwork = $Labdata.AllNodes.IPnetwork
     $NatName = $Labdata.AllNodes.IPNatName
 
-    $Index = Get-NetAdapter -name "vethernet ($LabSwitchName)" | Select-Object -ExpandProperty InterfaceIndex
+    $Index = Get-NetAdapter -name "vethernet ($LabSwitchName)*" | Select-Object -ExpandProperty InterfaceIndex
 
     if ($pscmdlet.ShouldProcess("Interface index $index", "New-NetIPAddress")) {
         New-NetIPAddress -InterfaceIndex $Index -IPAddress $GatewayIP -PrefixLength $GatewayPrefix -ErrorAction SilentlyContinue


### PR DESCRIPTION
Change for consideration on addressing issue with Ethernet interfaces have a number at the end.  Obviously if there's a cleaner way to do it, it should be done that way.